### PR TITLE
Add pointer-events property to avoid elements next to snackbar aren't clickable

### DIFF
--- a/src/snackbar.less
+++ b/src/snackbar.less
@@ -4,6 +4,7 @@
     left: 20px;
     bottom: 0;
     z-index: 99999;
+    pointer-events: none;
 }
 .snackbar {
     overflow: hidden;
@@ -12,6 +13,7 @@
     max-width: 568px;
     cursor: pointer;
     opacity: 0;
+    pointer-events: all;
 }
 
 .snackbar.snackbar-opened {


### PR DESCRIPTION
Add pointer-events property to container and to dedicated snackbars to avoid the container preventing clicking on elements that are next to a snackbar when using snackbars which are eg. centered (eg. in combination with the bootstrap-material-design) or don't have the same with due to different content lenght.